### PR TITLE
[EN-799] Add support to build linux arm64 binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ docker:
 		docker build -t golang-cross-compile .
 
 cross: docker
-	docker run -ti --rm -e CGO_ENABLED=0 -v $(CURDIR):/gopath/src/clair-scanner -w /gopath/src/clair-scanner golang-cross-compile gox -osarch="darwin/amd64 darwin/386 linux/amd64 linux/386 windows/amd64 windows/386" -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}"
+	docker run -ti --rm -e CGO_ENABLED=0 -v $(CURDIR):/gopath/src/clair-scanner -w /gopath/src/clair-scanner golang-cross-compile gox -osarch="darwin/amd64 darwin/386 linux/amd64 linux/arm64 linux/386 windows/amd64 windows/386" -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}"
 
 clean:
 	rm -rf dist
@@ -30,7 +30,7 @@ test:
 	go test
 
 pull:
-	docker pull alpine:3.5
+	docker pull alpine:3.18
 	docker pull debian:jessie
 
 db:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY : install ensure build docker rmdocker test integration integrationlinux
 
-install:	
+install:
 	go get -u golang.org/x/tools/cmd/cover
 	go get -u github.com/mattn/goveralls
 
@@ -15,7 +15,7 @@ docker:
 		docker build -t golang-cross-compile .
 
 cross: docker
-	docker run -ti --rm -e CGO_ENABLED=0 -v $(CURDIR):/gopath/src/clair-scanner -w /gopath/src/clair-scanner golang-cross-compile gox -osarch="darwin/amd64 darwin/386 linux/amd64 linux/arm64 linux/386 windows/amd64 windows/386" -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}"
+	docker run -ti --rm -e CGO_ENABLED=0 -v $(CURDIR):/gopath/src/clair-scanner -w /gopath/src/clair-scanner golang-cross-compile gox -osarch="darwin/amd64 darwin/arm64 linux/amd64 linux/arm64" -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}"
 
 clean:
 	rm -rf dist

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Note: This was forked from https://github.com/arminc/clair-scanner and simply contains changes to build the Linux ARM64 compatible release binaries.**
+
 # Clair scanner
 
 ![Maintenance](https://img.shields.io/maintenance/yes/2020.svg)
@@ -24,10 +26,10 @@ CoreOS has created an awesome container scan tool called Clair. Clair is also us
 
 This is where clair-scanner comes into place. The clair-scanner does the following:
 
-* Scans an image against Clair server
-* Compares the vulnerabilities against a whitelist
-* Tells you if there are vulnerabilities that are not in the whitelist and fails
-* If everything is fine it completes correctly
+- Scans an image against Clair server
+- Compares the vulnerabilities against a whitelist
+- Tells you if there are vulnerabilities that are not in the whitelist and fails
+- If everything is fine it completes correctly
 
 ## Clair server or standalone
 
@@ -41,16 +43,17 @@ The clair-scanner is a copy of the Clair 'analyze-local-images' <https://github.
 
 clair-scanner is available on Linux, MacOS, and Windows platforms.
 
-* Binaries for Linux, Windows, and Mac are available in the [releases](https://github.com/arminc/clair-scanner/releases) page.
-* You can also install from source. To do so you must:
-  1. Have go 1.11+ installed  
+- Binaries for Linux, Windows, and Mac are available in the [releases](https://github.com/arminc/clair-scanner/releases) page.
+- You can also install from source. To do so you must:
+
+  1. Have go 1.11+ installed
   1. Clone the repo
   1. Build and install the executable
 
   ```sh
   # Clone the repo
   git clone git@github.com:arminc/clair-scanner.git
-  # Build and install 
+  # Build and install
   cd clair-scanner
   make build
   make installLocal
@@ -158,6 +161,7 @@ images:
   alpine:
     CVE-2017-3261: SE
 ```
+
 ## Troubleshooting
 
 If you get `[CRIT] ▶ Could not save Docker image [image:version]: Error response from daemon: reference does not exist`, this means that image `image:version` is not locally present. You should have this image present locally before trying to analyze it (e.g.: `docker pull image:version`).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM --platform=linux/amd64 debian:bullseye
 
 RUN apt-get update -y && apt-get install --no-install-recommends -y -q \
     curl \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y -q \
     git mercurial bzr \
     && rm -rf /var/lib/apt/lists/*
 
-ENV GOVERSION 1.14
+ENV GOVERSION 1.19
 RUN mkdir /goroot && mkdir /gopath
 RUN curl https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz \
     | tar xvzf - -C /goroot --strip-components=1
@@ -17,4 +17,4 @@ ENV GOPATH /gopath
 ENV GOROOT /goroot
 ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH
 
-RUN go get github.com/mitchellh/gox
+RUN go install github.com/mitchellh/gox@latest

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/stretchr/testify v1.1.4
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
-	golang.org/x/sys v0.0.0-20190412213103-97732733099d
+	golang.org/x/sys v0.9.0
 	golang.org/x/tools v0.0.0-20200624225443-88f3c62a19ff // indirect
 	gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7
 )

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ golang.org/x/sys v0.0.0-20171006175012-ebfc5b463182/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.9.0 h1:KS/R3tvhPqvJvwcKfnBHJwwthS11LRhmM5D59eEXa0s=
+golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=


### PR DESCRIPTION
- Adding support for linux arm64 binaries
- Update version of Go to 1.19 used to build cross arch binaries
- Update version of `golang.org/x/sys` that is supports Go 1.19

GitHub Release will be created manually once the PR has been merged